### PR TITLE
Added recent projects to the list

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2" url="https://github.com/krasa/FrameSwitcher">
 	<name>Frame Switcher</name>
 	<id>FrameSwitcher</id>
-	<version>1.4</version>
+	<version>2.0</version>
   
 	<vendor url="https://github.com/krasa/FrameSwitcher" email="vojta.krasa@gmail.com">Vojtech
 		Krasa
@@ -13,7 +13,12 @@
       ]]></description>
 
   <change-notes><![CDATA[
-		  1.4		  
+          2.0
+         <br/> - recent projects list added to the popup
+         <br/> - alphanumeric mnemonics
+         <br/> - now current frame isn't disabled
+         <br/><br/>
+		  1.4
 		 <br> - usable during indexing
 		 <br> <br> 
 		  1.3 		  

--- a/src/krasa/frameswitcher/FrameSwitchAction.java
+++ b/src/krasa/frameswitcher/FrameSwitchAction.java
@@ -1,13 +1,6 @@
 package krasa.frameswitcher;
 
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-
-import javax.swing.*;
-
+import com.intellij.ide.RecentProjectsManager;
 import com.intellij.ide.actions.QuickSwitchSchemeAction;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -17,9 +10,15 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.IdeFrame;
 import com.intellij.openapi.wm.WindowManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 
 public class FrameSwitchAction extends QuickSwitchSchemeAction implements DumbAware {
 
@@ -39,17 +38,14 @@ public class FrameSwitchAction extends QuickSwitchSchemeAction implements DumbAw
 						component.grabFocus();
 					}
 				};
-				if (project != null) {
-					VirtualFile projectFile = project.getProjectFile();
-					VirtualFile projectFile1 = project1.getProjectFile();
-					if (projectFile != null && projectFile1 != null) {
-						boolean enabled = !projectFile.getPath().equals(projectFile1.getPath());
-						action.getTemplatePresentation().setEnabled(enabled);
-					}
-				}
 				group.addAction(action);
 			}
 		}
+        AnAction[] recentProjectsActions = RecentProjectsManager.getInstance().getRecentProjectsActions(false);
+        if (recentProjectsActions != null && recentProjectsActions.length > 0) {
+            group.addSeparator("Recent");
+            group.addAll(recentProjectsActions);
+        }
 	}
 
 	private ArrayList<IdeFrame> getIdeFrames() {
@@ -81,7 +77,7 @@ public class FrameSwitchAction extends QuickSwitchSchemeAction implements DumbAw
 		return true;
 	}
 	protected JBPopupFactory.ActionSelectionAid getAidMethod() {
-	   return JBPopupFactory.ActionSelectionAid.SPEEDSEARCH;
+	   return JBPopupFactory.ActionSelectionAid.ALPHA_NUMBERING;
 	 }
 	
 }


### PR DESCRIPTION
1. Added recent projects to the popup for quick access. It allows to switch to a project that you worked on before even if it isn't opened in IDE.
2. Turned on alphanumeric mnemonics for popup items for quicker keyboard access.
3. Current frame isn't disabled on the list to avoid a glitch of having the old current frame item disabled after you switched to another frame with cmd+` while FrameSwitcher popup is visible. Also, it's not obvious enough that selected item is also disabled, so it's confusing a bit when you hit Enter and nothing's happen.

PS I've put all of the changes into a single commit because they are tiny ones. Sorry if I did anything wrong, this is my first pull request on GitHub.
